### PR TITLE
Added support for carriage of ID3 tags in event message tracks.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,12 +4,12 @@ Status: FD
 Text Macro: SPECVERSION v1.0.0
 Title: Carriage of ID3 Timed Metadata in the Common Media Application Format (CMAF)
 URL: https://AOMediaCodec.github.io/id3-emsg
-Shortname: id3-esmg
+Shortname: id3-emsg
 Editor: Krasimir Kolarov, kolarov@apple.com; 
 Editor: John Simmons, johnsim@microsoft.com 
-Abstract: This specification defines how ID3 metadata can be carried as timed metadata in Common Media Application Format (CMAF) compatible fragmented MP4 streams using Event Message ('emsg') boxes.
+Abstract: This specification defines how ID3 metadata can be carried as timed metadata in Common Media Application Format (CMAF) compatible fragmented MP4 streams using Event Message ('emsg') and Event Message Instance ('emib') boxes.
 Date: 2020-03-12
-Repository: AOMediaCodec/id3-esmg
+Repository: AOMediaCodec/id3-emsg
 Inline Github Issues: full
 Boilerplate: property-index no, issues-index no, copyright yes
 Markup Shorthands: css no
@@ -51,7 +51,14 @@ Markup Shorthands: css no
 		"title": "Information technology — Dynamic adaptive streaming over HTTP (DASH) — Part 1: Media presentation description and segment formats",
 		"status": "Standard",
 		"publisher": "ISO"
-	} 
+	},
+	"EMSG-TRACK": {
+		"href": "https://www.iso.org/standard/82529.html",
+		"id": "EMSG-TRACK",
+		"title": "Information technology - MPEG systems technologies - Part 18: Event message track format for the ISO base media file format",
+		"status": "Standard",
+		"publisher": "ISO"
+	}
 }
 </pre>
 
@@ -66,6 +73,8 @@ url: https://www.iso.org/standard/65274.html#; spec: DASH; type: dfn;
 	text: presentation_time_delta
 	text: presentation_time
 	text: id
+url: https://www.iso.org/standard/82529.html#; spec: EMSG-TRACK; type: dfn;
+	text: emib
 </pre>
 
 # Introduction # {#introduction}
@@ -78,11 +87,13 @@ This specification describes how such ID3 metadata can be carried as timed metad
 
 CMAF-compatible fragmented MP4 can also be used in DASH. The elements defined in this specification may also be used with DASH.
 
+The specification also describes how ID3 metadata can be carried in a CMAF-compatible event message track as described in [[EMSG-TRACK]].
+
 # Timed Metadata in a CMAF-compatible stream # {#timed-meta}
 
 ## Overview ## {#meta-overview}
 
-Timed Metadata in a CMAF-compatible stream is signaled via one or more Event Message boxes (<code><a>emsg</a></code>) [[CMAF]] per segment.
+Timed Metadata in a CMAF-compatible stream can be signaled via one or more Event Message boxes (<code><a>emsg</a></code>) [[CMAF]] per segment. Timed Metadata can also be signaled via an Event Message Instance Box (<code><a>emib</a></code>) as defined in [[EMSG-TRACK]].
 
 Event messages with the scheme specified in this document will identify boxes that carry ID3v2 metadata [[ID3]].
 
@@ -94,7 +105,7 @@ One or more Event Message boxes (<code><a>emsg</a></code>) [[!CMAF]] can be incl
 
 ### Syntax ### {#emsg-syntax}
 
-For convenience, the follow box definition is reproduced from [[DASH]], section 5.10.3.3.3. 
+For convenience, the following box definition is reproduced from [[DASH]], section 5.10.3.3.3. 
 
 ```cpp
 aligned(8) class DASHEventMessageBox extends FullBox('emsg', version, flags = 0)
@@ -133,6 +144,37 @@ If in a particular case, the ID3 message carries a duration, it should be reflec
 The <a>presentation_time</a> must be within the time interval of the fragment.
 
 The <a>id</a> field is not restricted in this version of the specification.
+
+## ID3 Metadata in an Event Message Instance Box ## {#meta-emib}
+
+### Introduction ### {#emib-intro}
+
+In an event message track, one or more Event Message Instance Boxes (<code><a>emib</a></code>) can be included per segment.
+
+### Syntax ### {#emib-syntax}
+
+For convenience, the following box definition is reproduced from [[EMSG-TRACK]], section 6.1.2.
+
+```cpp
+aligned(8) class EventMessageInstanceBox extends FullBox('emib', version, flags = 0) {
+	unsigned int(32)    reserved = 0;
+	signed int(64)      presentation_time_delta;
+	unsigned int(32)    event_duration;
+	unsigned int(32)    id;
+	string              scheme_id_uri;
+	string              value;
+	unsigned int(8)     message_data[];
+}
+```
+
+### Semantics ### {#emib-semantics}
+
+The <a>id</a>, <a>scheme_id_uri</a>, <a>value</a>, and <a>message_data</a> semantics are identical to the Event Message Box semantics.
+
+The <a>presentation_time_delta</a> semantics defined in [[EMSG-TRACK]] remain unchanged.
+
+In general, ID3 don't carry a duration and in those cases the <a>event_duration</a> field should be set to <code>0</code>.
+If in a particular case, the ID3 message carries a duration, it should be reflected in the <a>event_duration</a> field.
 
 ## Signaling ## {#meta-signaling}
 


### PR DESCRIPTION
Resolves https://github.com/AOMediaCodec/id3-emsg/issues/45


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jsaxton/id3-emsg/pull/50.html" title="Last updated on Feb 17, 2025, 11:59 PM UTC (0f63700)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/id3-emsg/50/eeae942...jsaxton:0f63700.html" title="Last updated on Feb 17, 2025, 11:59 PM UTC (0f63700)">Diff</a>